### PR TITLE
Completed CLI `--version`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,12 @@
 - Added options to `python_install_namespace_package` to overwrite `setup.cfg`.
 - Added wheel build/install to `python_install_namespace_package`.
 - Added source dependencies to generate_docstrings to avoid rebuilding docstrings.h.
+- Added "--version" to Python CLI.
 
 ### Fixed
 
 - Corrected conversion between `simFloat` and `ng_float_t`  in `navground_coppelia_sim`.
+- Fixed version returned by C++ CLI.
 
 ### Changed
 

--- a/navground_core/include/navground/core/command.h
+++ b/navground_core/include/navground/core/command.h
@@ -1,18 +1,21 @@
 #ifndef NAVGROUND_CORE_COMMAND_H
 #define NAVGROUND_CORE_COMMAND_H
 
+#include "navground/core/plugins.h"
+#include "navground/core/version.h"
 #include <argparse/argparse.hpp>
-#include <navground/core/plugins.h>
 #include <iostream>
 #include <string>
 
 template <typename T> struct Command {
 
 public:
-  explicit Command(const std::string &name = "") : name(name) {}
+  explicit Command(const std::string &name = "",
+                   const std::string &version = "")
+      : name(name), version(version) {}
 
   int run(int argc, char *argv[]) {
-    argparse::ArgumentParser parser(name);
+    argparse::ArgumentParser parser(name, version);
     parser.add_argument("--no-plugins")
         .help("Do not load plugins")
         .default_value(false)
@@ -31,6 +34,7 @@ public:
     return static_cast<T *>(this)->execute(parser);
   }
   std::string name;
+  std::string version;
 };
 
 #endif // NAVGROUND_CORE_COMMAND_H

--- a/navground_core/include/navground/core/echo.h
+++ b/navground_core/include/navground/core/echo.h
@@ -31,8 +31,9 @@ struct EchoCommand : Command<EchoCommand> {
 
   using Echos = std::map<std::string, std::function<bool(const YAML::Node &)>>;
 
-  explicit EchoCommand(const std::string &name, const Echos &echos)
-      : Command<EchoCommand>(name), echos(echos) {}
+  explicit EchoCommand(const std::string &name, const std::string &version,
+                       const Echos &echos)
+      : Command<EchoCommand>(name, version), echos(echos) {}
 
   void setup(argparse::ArgumentParser &parser) {
     parser.add_description(

--- a/navground_core/include/navground/core/info.h
+++ b/navground_core/include/navground/core/info.h
@@ -12,15 +12,17 @@
 namespace navground::core {
 
 // inline void print_build_info(const BuildInfo &bi) {
-//   std::cout << "version:             " << bi.get_version_string() << std::endl;
-//   std::cout << "git commit:          " << bi.git_commit << std::endl;
-//   std::cout << "build date:          " << bi.date << std::endl;
-//   std::cout << "floating-point type: " << bi.floating_point_type << std::endl;
+//   std::cout << "version:             " << bi.get_version_string() <<
+//   std::endl; std::cout << "git commit:          " << bi.git_commit <<
+//   std::endl; std::cout << "build date:          " << bi.date << std::endl;
+//   std::cout << "floating-point type: " << bi.floating_point_type <<
+//   std::endl;
 // }
 
 // inline void print_build_dependencies(const BuildDependencies &bd) {
 //   for (const auto & [name, vs] : bd) {
-//     std::cout << "name: " << dependencies_difference_to_string(vs) << std::endl; 
+//     std::cout << "name: " << dependencies_difference_to_string(vs) <<
+//     std::endl;
 //   }
 // }
 
@@ -29,11 +31,11 @@ struct InfoCommand : Command<InfoCommand> {
   using TitledRegisters =
       std::map<std::string, std::function<PropertyRegister()>>;
 
-  explicit InfoCommand(const std::string &name,
+  explicit InfoCommand(const std::string &name, const std::string &version,
                        const TitledRegisters titled_registers,
                        const BuildInfo &bi, const BuildDependencies &bd)
-      : Command<InfoCommand>(name), titled_registers(titled_registers), bi(bi),
-        bd(bd) {}
+      : Command<InfoCommand>(name, version), titled_registers(titled_registers),
+        bi(bi), bd(bd) {}
 
   void setup(argparse::ArgumentParser &parser) {
     parser.add_description("Lists registered components.");

--- a/navground_core/include/navground/core/list_plugins.h
+++ b/navground_core/include/navground/core/list_plugins.h
@@ -24,8 +24,9 @@ inline std::string title(const std::string &name) {
 struct ListPluginsCommand : Command<ListPluginsCommand> {
 
   explicit ListPluginsCommand(const std::string &name,
+                              const std::string &version,
                               const std::vector<std::string> &kinds)
-      : Command<ListPluginsCommand>(name), kinds(kinds) {}
+      : Command<ListPluginsCommand>(name, version), kinds(kinds) {}
 
   void setup(argparse::ArgumentParser &parser) {
     parser.add_description("Load and list plugins");

--- a/navground_core/include/navground/core/schema.h
+++ b/navground_core/include/navground/core/schema.h
@@ -36,10 +36,10 @@ struct SchemaCommand : Command<SchemaCommand> {
       {"behavior_modulation", &component<core::BehaviorModulation>},
       {"kinematics", &component<core::Kinematics>}};
 
-  explicit SchemaCommand(const std::string &name,
+  explicit SchemaCommand(const std::string &name, const std::string &version,
                          const std::string &default_schema,
                          const Schemas &extra_schemas = {})
-      : Command<SchemaCommand>(name), schemas(core_schemas),
+      : Command<SchemaCommand>(name, version), schemas(core_schemas),
         default_schema(default_schema) {
     schemas.insert(extra_schemas.begin(), extra_schemas.end());
   }

--- a/navground_core/src/echo.cpp
+++ b/navground_core/src/echo.cpp
@@ -2,6 +2,7 @@
 #include "navground/core/behavior.h"
 #include "navground/core/behavior_modulation.h"
 #include "navground/core/kinematics.h"
+#include "navground/core/version.h"
 #include "navground/core/yaml/core.h"
 
 namespace core = navground::core;
@@ -9,8 +10,9 @@ using core::EchoCommand;
 
 int main(int argc, char *argv[]) {
   return core::EchoCommand(
-             "echo", {{"behavior", &core::echo<core::Behavior>},
-                      {"modulation", &core::echo<core::BehaviorModulation>},
-                      {"kinematics", &core::echo<core::Kinematics>}})
+             "echo", navground::core::build_info().get_version_string(),
+             {{"behavior", &core::echo<core::Behavior>},
+              {"modulation", &core::echo<core::BehaviorModulation>},
+              {"kinematics", &core::echo<core::Kinematics>}})
       .run(argc, argv);
 }

--- a/navground_core/src/info.cpp
+++ b/navground_core/src/info.cpp
@@ -7,10 +7,11 @@
 #include "navground/core/behavior_modulation.h"
 #include "navground/core/build_info.h"
 #include "navground/core/kinematics.h"
+#include "navground/core/version.h"
 
 int main(int argc, char *argv[]) {
   navground::core::InfoCommand cmd(
-      "info",
+      "info", navground::core::build_info().get_version_string(),
       {{"Behaviors", navground::core::Behavior::type_properties},
        {"Kinematics", navground::core::Kinematics::type_properties},
        {"Modulations", navground::core::BehaviorModulation::type_properties}},

--- a/navground_core/src/list_plugins.cpp
+++ b/navground_core/src/list_plugins.cpp
@@ -2,12 +2,14 @@
 #include "navground/core/behavior.h"
 #include "navground/core/behavior_modulation.h"
 #include "navground/core/kinematics.h"
+#include "navground/core/version.h"
 
 namespace core = navground::core;
 using core::ListPluginsCommand;
 
 int main(int argc, char *argv[]) {
-  return core::ListPluginsCommand("plugins",
-                                  {"behaviors", "modulations", "kinematics"})
+  return core::ListPluginsCommand(
+             "plugins", navground::core::build_info().get_version_string(),
+             {"behaviors", "modulations", "kinematics"})
       .run(argc, argv);
 }

--- a/navground_core/src/schema.cpp
+++ b/navground_core/src/schema.cpp
@@ -1,8 +1,12 @@
 #include "navground/core/schema.h"
+#include "navground/core/version.h"
 #include "navground/core/yaml/schema_core.h"
 
 namespace core = navground::core;
 
 int main(int argc, char *argv[]) {
-  return core::SchemaCommand("schema", "core").run(argc, argv);
+  return core::SchemaCommand("schema",
+                             navground::core::build_info().get_version_string(),
+                             "core")
+      .run(argc, argv);
 }

--- a/navground_core_py/navground/core/command.py
+++ b/navground_core_py/navground/core/command.py
@@ -6,10 +6,11 @@ import typing
 from navground import core
 
 
-def init_parser(parser: argparse.ArgumentParser) -> None:
+def init_parser(parser: argparse.ArgumentParser, version: str) -> None:
     parser.add_argument('--no-plugins',
                         help="Do not load plugins",
                         action='store_true')
+    parser.add_argument('-v', '--version', action='version', version=version)
 
 
 def _main(arg: argparse.Namespace,

--- a/navground_core_py/navground/core/echo.py
+++ b/navground_core_py/navground/core/echo.py
@@ -24,9 +24,9 @@ def description() -> str:
     return "Load an object from YAML and print its YAML representation."
 
 
-def init_parser_with_echos(parser: argparse.ArgumentParser,
+def init_parser_with_echos(parser: argparse.ArgumentParser, version: str,
                            echos: Echos) -> None:
-    command.init_parser(parser)
+    command.init_parser(parser, version)
     kinds = ", ".join(echos.keys())
     parser.add_argument("kind",
                         type=str,
@@ -44,7 +44,7 @@ def init_parser_with_echos(parser: argparse.ArgumentParser,
 
 
 def init_parser(parser: argparse.ArgumentParser) -> None:
-    init_parser_with_echos(parser, echos)
+    init_parser_with_echos(parser, core.get_build_info().version_string, echos)
 
 
 def parser() -> argparse.ArgumentParser:

--- a/navground_core_py/navground/core/info.py
+++ b/navground_core_py/navground/core/info.py
@@ -29,9 +29,9 @@ def add_arg_for_register(parser: argparse.ArgumentParser, title: str) -> None:
                         metavar=title.upper())
 
 
-def init_parser_with_registers(parser: argparse.ArgumentParser,
+def init_parser_with_registers(parser: argparse.ArgumentParser, version: str,
                                registers: Registers) -> None:
-    command.init_parser(parser)
+    command.init_parser(parser, version)
     parser.description = description()
     parser.add_argument('--build',
                         help="Include build infos",
@@ -47,7 +47,8 @@ def init_parser_with_registers(parser: argparse.ArgumentParser,
 
 
 def init_parser(parser: argparse.ArgumentParser) -> None:
-    init_parser_with_registers(parser, registers)
+    init_parser_with_registers(parser,
+                               core.get_build_info().version_string, registers)
 
 
 def parser() -> argparse.ArgumentParser:

--- a/navground_core_py/navground/core/list_plugins.py
+++ b/navground_core_py/navground/core/list_plugins.py
@@ -9,11 +9,17 @@ def description() -> str:
     return "Load and list plugins."
 
 
-def init_parser(parser: argparse.ArgumentParser) -> None:
+def init_parser_with_version(parser: argparse.ArgumentParser,
+                             version: str) -> None:
     parser.description = description()
+    parser.add_argument('-v', '--version', action='version', version=version)
     parser.add_argument('--dependencies',
                         help="Display dependencies of C++ plugins",
                         action='store_true')
+
+
+def init_parser(parser: argparse.ArgumentParser) -> None:
+    init_parser_with_version(parser, core.get_build_info().version_string)
 
 
 def parser() -> argparse.ArgumentParser:

--- a/navground_core_py/navground/core/main.py
+++ b/navground_core_py/navground/core/main.py
@@ -4,7 +4,7 @@ import argparse
 from types import ModuleType
 from typing import Any
 
-from . import echo, info, list_plugins, print_schema, validate
+from . import echo, info, list_plugins, print_schema, validate, get_build_info
 
 
 def config_parser(parsers: Any, name: str, module: ModuleType) -> None:
@@ -14,6 +14,10 @@ def config_parser(parsers: Any, name: str, module: ModuleType) -> None:
 
 
 def init_parser(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument('-v',
+                        '--version',
+                        action='version',
+                        version=get_build_info().version_string)
     parsers = parser.add_subparsers(dest='cmd', title='Subcommands')
     config_parser(parsers, 'info', info)
     config_parser(parsers, 'echo', echo)

--- a/navground_core_py/navground/core/print_schema.py
+++ b/navground_core_py/navground/core/print_schema.py
@@ -28,10 +28,10 @@ def description() -> str:
     return "Prints the YAML schema"
 
 
-def init_parser_with_schemas(parser: argparse.ArgumentParser,
+def init_parser_with_schemas(parser: argparse.ArgumentParser, version: str,
                              default_schema: str, schemas: Schemas,
                              components: Components) -> None:
-    command.init_parser(parser)
+    command.init_parser(parser, version)
     kinds = list(set(schemas.keys()) | set(components.keys()))
     parser.add_argument("kind",
                         type=str,
@@ -53,7 +53,9 @@ def init_parser_with_schemas(parser: argparse.ArgumentParser,
 
 
 def init_parser(parser: argparse.ArgumentParser) -> None:
-    init_parser_with_schemas(parser, 'core', schemas, components)
+    init_parser_with_schemas(parser,
+                             core.get_build_info().version_string, 'core',
+                             schemas, components)
 
 
 def parser() -> argparse.ArgumentParser:

--- a/navground_core_py/navground/core/validate.py
+++ b/navground_core_py/navground/core/validate.py
@@ -17,9 +17,9 @@ def description() -> str:
     return "Validate YAML."
 
 
-def init_parser_with_kinds(parser: argparse.ArgumentParser,
+def init_parser_with_kinds(parser: argparse.ArgumentParser, version: str,
                            kinds: list[str]) -> None:
-    command.init_parser(parser)
+    command.init_parser(parser, version)
     parser.add_argument("kind",
                         type=str,
                         help="The kind of object to validate",
@@ -31,7 +31,7 @@ def init_parser_with_kinds(parser: argparse.ArgumentParser,
 
 
 def init_parser(parser: argparse.ArgumentParser) -> None:
-    init_parser_with_kinds(parser, kinds)
+    init_parser_with_kinds(parser, core.get_build_info().version_string, kinds)
 
 
 def parser() -> argparse.ArgumentParser:
@@ -40,7 +40,8 @@ def parser() -> argparse.ArgumentParser:
     return p
 
 
-def validate(arg: argparse.Namespace, kinds: list[str], schema: dict[str, Any]) -> None:
+def validate(arg: argparse.Namespace, kinds: list[str],
+             schema: dict[str, Any]) -> None:
     import jsonschema
 
     if arg.kind not in kinds:

--- a/navground_sim/src/echo.cpp
+++ b/navground_sim/src/echo.cpp
@@ -3,6 +3,7 @@
 #include "navground/core/behavior_modulation.h"
 #include "navground/core/kinematics.h"
 #include "navground/core/yaml/core.h"
+#include "navground/sim/version.h"
 #include "navground/sim/yaml/experiment.h"
 #include "navground/sim/yaml/scenario.h"
 #include "navground/sim/yaml/world.h"
@@ -13,7 +14,7 @@ using core::EchoCommand;
 
 int main(int argc, char *argv[]) {
   return core::EchoCommand(
-             "echo",
+             "echo", navground::sim::build_info().get_version_string(),
              {
                  {"behavior", &core::echo<core::Behavior>},
                  {"modulation", &core::echo<core::BehaviorModulation>},

--- a/navground_sim/src/info.cpp
+++ b/navground_sim/src/info.cpp
@@ -6,14 +6,15 @@
 #include "navground/core/behavior.h"
 #include "navground/core/behavior_modulation.h"
 #include "navground/core/kinematics.h"
+#include "navground/sim/build_info.h"
 #include "navground/sim/scenario.h"
 #include "navground/sim/state_estimation.h"
 #include "navground/sim/task.h"
-#include "navground/sim/build_info.h"
+#include "navground/sim/version.h"
 
 int main(int argc, char *argv[]) {
   navground::core::InfoCommand cmd(
-      "info",
+      "info", navground::sim::build_info().get_version_string(),
       {{"Behaviors", navground::core::Behavior::type_properties},
        {"Kinematics", navground::core::Kinematics::type_properties},
        {"Modulations", navground::core::BehaviorModulation::type_properties},

--- a/navground_sim/src/list_plugins.cpp
+++ b/navground_sim/src/list_plugins.cpp
@@ -3,10 +3,12 @@
  */
 
 #include "navground/core/list_plugins.h"
+#include "navground/sim/version.h"
 
 int main(int argc, char *argv[]) {
   navground::core::ListPluginsCommand cmd(
-      "plugins", {"behaviors", "kinematics", "modulations", "state_estimations",
-                  "tasks", "scenarios"});
+      "plugins", navground::sim::build_info().get_version_string(),
+      {"behaviors", "kinematics", "modulations", "state_estimations", "tasks",
+       "scenarios"});
   return cmd.run(argc, argv);
 }

--- a/navground_sim/src/main.cpp
+++ b/navground_sim/src/main.cpp
@@ -12,6 +12,7 @@
 #include "navground/core/yaml/core.h"
 #include "navground/sim/build_info.h"
 #include "navground/sim/schema.h"
+#include "navground/sim/version.h"
 #include "navground/sim/yaml/world.h"
 #include "run_command.h"
 #include "sample_command.h"
@@ -25,9 +26,16 @@ namespace core = navground::core;
 struct MainCommand : Command<MainCommand> {
 
   explicit MainCommand(const std::string &name)
-      : Command<MainCommand>(name), _rp("run"), _sp("sample"), _ip("info"),
-        _ep("echo"), _xp("schema"), _pp("plugins"), _run(), _sample(),
-        _info("",
+      : Command<MainCommand>(name,
+                             navground::sim::build_info().get_version_string()),
+        _rp("run", navground::sim::build_info().get_version_string()),
+        _sp("sample", navground::sim::build_info().get_version_string()),
+        _ip("info", navground::sim::build_info().get_version_string()),
+        _ep("echo", navground::sim::build_info().get_version_string()),
+        _xp("schema", navground::sim::build_info().get_version_string()),
+        _pp("plugins", navground::sim::build_info().get_version_string()),
+        _run(), _sample(),
+        _info("", "",
               {{"Behaviors", navground::core::Behavior::type_properties},
                {"Kinematics", navground::core::Kinematics::type_properties},
                {"Modulations",
@@ -38,7 +46,7 @@ struct MainCommand : Command<MainCommand> {
                {"Scenarios", navground::sim::Scenario::type_properties}},
               navground::sim::get_build_info(),
               navground::sim::get_build_dependencies()),
-        _echo("",
+        _echo("", "",
               {
                   {"behavior", &core::echo<core::Behavior>},
                   {"modulation", &core::echo<core::BehaviorModulation>},
@@ -50,9 +58,10 @@ struct MainCommand : Command<MainCommand> {
                   {"agent", &core::echo_s<sim::Agent>},
                   {"experiment", &core::echo_s<sim::Experiment>},
               }),
-        _schema("", "sim", schemas()),
-        _list_plugins("", {"behaviors", "kinematics", "modulations",
-                           "state_estimations", "tasks", "scenarios"}) {}
+        _schema("", "", "sim", schemas()),
+        _list_plugins("", "",
+                      {"behaviors", "kinematics", "modulations",
+                       "state_estimations", "tasks", "scenarios"}) {}
 
   void setup(argparse::ArgumentParser &parser) {
     _run.setup(_rp);

--- a/navground_sim/src/run.cpp
+++ b/navground_sim/src/run.cpp
@@ -2,9 +2,11 @@
  * @author Jerome Guzzi - <jerome@idsia.ch>
  */
 
-
+#include "navground/sim/version.h"
 #include "run_command.h"
 
 int main(int argc, char *argv[]) {
-  return navground::sim::RunCommand("run").run(argc, argv);
+  return navground::sim::RunCommand(
+             "run", navground::sim::build_info().get_version_string())
+      .run(argc, argv);
 }

--- a/navground_sim/src/sample.cpp
+++ b/navground_sim/src/sample.cpp
@@ -2,9 +2,11 @@
  * @author Jerome Guzzi - <jerome@idsia.ch>
  */
 
-
+#include "navground/sim/version.h"
 #include "sample_command.h"
 
 int main(int argc, char *argv[]) {
-  return navground::sim::SampleCommand("sample").run(argc, argv);
+  return navground::sim::SampleCommand(
+             "sample", navground::sim::build_info().get_version_string())
+      .run(argc, argv);
 }

--- a/navground_sim/src/schema.cpp
+++ b/navground_sim/src/schema.cpp
@@ -1,9 +1,13 @@
 #include "navground/core/schema.h"
 #include "navground/sim/schema.h"
+#include "navground/sim/version.h"
 
 using navground::core::SchemaCommand;
 using navground::sim::schemas;
 
 int main(int argc, char *argv[]) {
-  return SchemaCommand("schema", "sim", schemas()).run(argc, argv);
+  return SchemaCommand("schema",
+                       navground::sim::build_info().get_version_string(), "sim",
+                       schemas())
+      .run(argc, argv);
 }

--- a/navground_sim_py/navground/sim/echo.py
+++ b/navground_sim_py/navground/sim/echo.py
@@ -18,7 +18,8 @@ description = echo.description
 
 
 def init_parser(parser: argparse.ArgumentParser) -> None:
-    echo.init_parser_with_echos(parser, echos)
+    echo.init_parser_with_echos(parser,
+                                sim.get_build_info().version_string, echos)
 
 
 def parser() -> argparse.ArgumentParser:

--- a/navground_sim_py/navground/sim/info.py
+++ b/navground_sim_py/navground/sim/info.py
@@ -13,7 +13,8 @@ registers = core_registers + [(sim.StateEstimation, "State Estimations"),
 
 
 def init_parser(parser: argparse.ArgumentParser) -> None:
-    init_parser_with_registers(parser, registers)
+    init_parser_with_registers(parser,
+                               sim.get_build_info().version_string, registers)
 
 
 def parser() -> argparse.ArgumentParser:

--- a/navground_sim_py/navground/sim/list_plugins.py
+++ b/navground_sim_py/navground/sim/list_plugins.py
@@ -3,8 +3,18 @@ from __future__ import annotations
 import argparse
 
 from navground import sim
-from navground.core.list_plugins import (description,  # noqa: F401
-                                         init_parser, list_plugins, parser)
+from navground.core.list_plugins import description  # noqa: F401
+from navground.core.list_plugins import list_plugins, init_parser_with_version
+
+
+def init_parser(parser: argparse.ArgumentParser) -> None:
+    init_parser_with_version(parser, sim.get_build_info().version_string)
+
+
+def parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser()
+    init_parser(p)
+    return p
 
 
 def _main(arg: argparse.Namespace) -> None:

--- a/navground_sim_py/navground/sim/main.py
+++ b/navground_sim_py/navground/sim/main.py
@@ -4,8 +4,8 @@ import argparse
 from types import ModuleType
 from typing import Any
 
-from . import (echo, info, list_plugins, print_schema, record_video, replay,
-               run, run_rt, sample, validate)
+from . import (echo, get_build_info, info, list_plugins, print_schema,
+               record_video, replay, run, run_rt, sample, validate)
 
 
 def config_parser(parsers: Any, name: str, module: ModuleType) -> None:
@@ -15,6 +15,10 @@ def config_parser(parsers: Any, name: str, module: ModuleType) -> None:
 
 
 def init_parser(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument('-v',
+                        '--version',
+                        action='version',
+                        version=get_build_info().version_string)
     parsers = parser.add_subparsers(dest='cmd',
                                     title='Subcommands',
                                     metavar="{info,run,...}")

--- a/navground_sim_py/navground/sim/print_schema.py
+++ b/navground_sim_py/navground/sim/print_schema.py
@@ -22,7 +22,9 @@ description = print_schema.description
 
 
 def init_parser(parser: argparse.ArgumentParser) -> None:
-    print_schema.init_parser_with_schemas(parser, 'sim', schemas, components)
+    print_schema.init_parser_with_schemas(parser,
+                                          sim.get_build_info().version_string,
+                                          'sim', schemas, components)
 
 
 def parser() -> argparse.ArgumentParser:

--- a/navground_sim_py/navground/sim/record_video.py
+++ b/navground_sim_py/navground/sim/record_video.py
@@ -7,6 +7,7 @@ import random
 import sys
 from typing import TYPE_CHECKING, Any
 import pathlib
+from navground import sim
 from navground.core import command
 from navground.core.utils import chdir
 
@@ -56,7 +57,7 @@ def description() -> str:
 
 
 def init_parser(parser: argparse.ArgumentParser) -> None:
-    command.init_parser(parser)
+    command.init_parser(parser, sim.get_build_info().version_string)
     parser.description = description()
     parser.add_argument(
         'input',
@@ -164,8 +165,7 @@ def main(decorate: Decorate | None = None) -> None:
     _main(arg, decorate=decorate)
 
 
-def _main(arg: argparse.Namespace,
-          decorate: Decorate | None = None) -> None:
+def _main(arg: argparse.Namespace, decorate: Decorate | None = None) -> None:
     command._main(arg, load_plugins)
     logging.basicConfig(level=logging.INFO)
     experiment = _load_recorded_experiment(arg.input) or _load_experiment(

--- a/navground_sim_py/navground/sim/replay.py
+++ b/navground_sim_py/navground/sim/replay.py
@@ -7,12 +7,15 @@ import pathlib
 import sys
 from typing import TYPE_CHECKING
 
+from navground import sim
+
 from .real_time import RealTimeSimulation
 from .recorded_experiment import RecordedExperiment, RecordedExperimentalRun
 
 if TYPE_CHECKING:
-    from .ui import Rect, WebUI
     import h5py  # type: ignore[import-untyped]
+
+    from .ui import Rect, WebUI
 
 
 class RealTimeReplay(RealTimeSimulation):
@@ -68,6 +71,10 @@ def description() -> str:
 
 def init_parser(parser: argparse.ArgumentParser) -> None:
     parser.description = description()
+    parser.add_argument('-v',
+                        '--version',
+                        action='version',
+                        version=sim.get_build_info().version_string)
     parser.add_argument('path',
                         help='The path an HDF5 file that store an experiment',
                         type=str)

--- a/navground_sim_py/navground/sim/run.py
+++ b/navground_sim_py/navground/sim/run.py
@@ -16,7 +16,7 @@ def description() -> str:
 
 
 def init_parser(parser: argparse.ArgumentParser) -> None:
-    command.init_parser(parser)
+    command.init_parser(parser, sim.get_build_info().version_string)
     parser.description = description()
     parser.add_argument(
         'YAML',

--- a/navground_sim_py/navground/sim/run_rt.py
+++ b/navground_sim_py/navground/sim/run_rt.py
@@ -7,12 +7,13 @@ import os
 import pathlib
 import random
 import sys
-from typing import TYPE_CHECKING
 from collections.abc import Callable
+from typing import TYPE_CHECKING
 
 from navground.core import command
 
-from . import Experiment, World, Scenario, load_experiment, load_plugins
+from . import (Experiment, Scenario, World, get_build_info, load_experiment,
+               load_plugins)
 from .real_time import RealTimeSimulation
 
 if TYPE_CHECKING:
@@ -84,7 +85,7 @@ def description() -> str:
 
 
 def init_parser(parser: argparse.ArgumentParser) -> None:
-    command.init_parser(parser)
+    command.init_parser(parser, get_build_info().version_string)
     parser.description = description()
     parser.add_argument(
         'YAML',
@@ -145,8 +146,7 @@ def init_parser(parser: argparse.ArgumentParser) -> None:
         default='')
 
 
-def _main(arg: argparse.Namespace,
-          decorate: Decorate | None = None) -> None:
+def _main(arg: argparse.Namespace, decorate: Decorate | None = None) -> None:
     command._main(arg, load_plugins)
     logging.basicConfig(level=logging.INFO)
     if os.path.exists(arg.YAML) and os.path.isfile(arg.YAML):

--- a/navground_sim_py/navground/sim/sample.py
+++ b/navground_sim_py/navground/sim/sample.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import argparse
 import logging
 import os
-import sys
 import pathlib
+import sys
 
 from navground import sim
 from navground.core import command
@@ -16,7 +16,7 @@ def description() -> str:
 
 
 def init_parser(parser: argparse.ArgumentParser) -> None:
-    command.init_parser(parser)
+    command.init_parser(parser, sim.get_build_info().version_string)
     parser.description = description()
     parser.add_argument(
         'YAML',

--- a/navground_sim_py/navground/sim/validate.py
+++ b/navground_sim_py/navground/sim/validate.py
@@ -13,7 +13,8 @@ description = validate.description
 
 
 def init_parser(parser: argparse.ArgumentParser) -> None:
-    validate.init_parser_with_kinds(parser, kinds)
+    validate.init_parser_with_kinds(parser,
+                                    sim.get_build_info().version_string, kinds)
 
 
 def parser() -> argparse.ArgumentParser:


### PR DESCRIPTION
Now both Python and C++ CLI print the correct version and exit when provided with argument `--version` or `-v`.

- Added `--version` to Python commands
- Corrected version returned by C++ commands (before it used a default "1.0").