### PR TITLE
Fixed dtype comparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 
 - Fixed an error that wrongly marked `Direction` task as done.
 - Fixed typo in wall-disc collision computation.
+- Fixed dtype comparison to use `equal` instead of `is`.
 
 ### Changed
 

--- a/navground_sim_py/navground/sim/_navground_sim.pyi
+++ b/navground_sim_py/navground/sim/_navground_sim.pyi
@@ -392,7 +392,7 @@ class LocalGridMapStateEstimation(Sensor):
     def read_transform_with_name(state: navground.core._navground.SensingState, name: str) -> navground.core._navground.Pose2 | None: ...
     def get_description(self) -> dict[str, navground.core._navground.BufferDescription]: ...
 
-class NativeAgent(Entity):
+class NativeAgent(Entity, navground.core._navground.HasAttributes):
     angular_speed: float
     behavior: navground.core._navground.Behavior | None
     color: str
@@ -428,7 +428,7 @@ class NativeAgent(Entity):
     @property
     def time_since_stuck(self) -> float: ...
 
-class NativeWorld:
+class NativeWorld(navground.core._navground.HasAttributes):
     bounding_box: BoundingBox
     collisions: set[tuple[Entity, Entity]]
     seed: int

--- a/navground_sim_py/navground/sim/ui/to_svg.py
+++ b/navground_sim_py/navground/sim/ui/to_svg.py
@@ -238,7 +238,8 @@ def svg_for_world(
     :param      grid_thickness:         The thickness of the grid
     :param      rotation:               A planar rotation applied before drawing [rad]
     :param      extras:                 Provides extras rendering added at the end of to the svg
-    :param      background_extras:                 Provides extras rendering added at the beginning of to the svg
+    :param      background_extras:      Provides extras rendering added at the
+                                        beginning of to the svg
 
     :returns:   An SVG string
     """

--- a/navground_sim_py/src/python.cpp
+++ b/navground_sim_py/src/python.cpp
@@ -918,26 +918,26 @@ template <typename T> static py::array make_empty_array() {
 void set_dataset_type_py(Dataset &dataset, const py::object &obj) {
   py::module_ np = py::module_::import("numpy");
   py::dtype dtype = np.attr("dtype")(obj);
-  if (dtype.is(py::dtype::of<int8_t>())) {
+  if (dtype.equal(py::dtype::of<int8_t>())) {
     dataset.set_dtype<int8_t>();
-  } else if (dtype.is(py::dtype::of<int16_t>())) {
+  } else if (dtype.equal(py::dtype::of<int16_t>())) {
     dataset.set_dtype<int16_t>();
-  } else if (dtype.is(py::dtype::of<int32_t>())) {
+  } else if (dtype.equal(py::dtype::of<int32_t>())) {
     dataset.set_dtype<int32_t>();
-  } else if (dtype.is(py::dtype::of<int64_t>())) {
+  } else if (dtype.equal(py::dtype::of<int64_t>())) {
     dataset.set_dtype<int64_t>();
-  } else if (dtype.is(py::dtype::of<uint8_t>()) ||
-             dtype.is(py::dtype::of<bool>())) {
+  } else if (dtype.equal(py::dtype::of<uint8_t>()) ||
+             dtype.equal(py::dtype::of<bool>())) {
     dataset.set_dtype<uint8_t>();
-  } else if (dtype.is(py::dtype::of<uint16_t>())) {
+  } else if (dtype.equal(py::dtype::of<uint16_t>())) {
     dataset.set_dtype<uint16_t>();
-  } else if (dtype.is(py::dtype::of<uint32_t>())) {
+  } else if (dtype.equal(py::dtype::of<uint32_t>())) {
     dataset.set_dtype<uint32_t>();
-  } else if (dtype.is(py::dtype::of<uint64_t>())) {
+  } else if (dtype.equal(py::dtype::of<uint64_t>())) {
     dataset.set_dtype<uint64_t>();
-  } else if (dtype.is(py::dtype::of<float>())) {
+  } else if (dtype.equal(py::dtype::of<float>())) {
     dataset.set_dtype<float>();
-  } else if (dtype.is(py::dtype::of<double>())) {
+  } else if (dtype.equal(py::dtype::of<double>())) {
     dataset.set_dtype<double>();
   } else {
     py::print("Type unknown", dtype);
@@ -945,35 +945,35 @@ void set_dataset_type_py(Dataset &dataset, const py::object &obj) {
 }
 
 Dataset::Data data_of_type(py::dtype dtype, void *ptr, const size_t size) {
-  if (dtype.is(py::dtype::of<int8_t>())) {
+  if (dtype.equal(py::dtype::of<int8_t>())) {
     auto begin = reinterpret_cast<int8_t *>(ptr);
     return std::vector<int8_t>(begin, begin + size);
-  } else if (dtype.is(py::dtype::of<int16_t>())) {
+  } else if (dtype.equal(py::dtype::of<int16_t>())) {
     auto begin = reinterpret_cast<int16_t *>(ptr);
     return std::vector<int16_t>(begin, begin + size);
-  } else if (dtype.is(py::dtype::of<int32_t>())) {
+  } else if (dtype.equal(py::dtype::of<int32_t>())) {
     auto begin = reinterpret_cast<int32_t *>(ptr);
     return std::vector<int32_t>(begin, begin + size);
-  } else if (dtype.is(py::dtype::of<int64_t>())) {
+  } else if (dtype.equal(py::dtype::of<int64_t>())) {
     auto begin = reinterpret_cast<int64_t *>(ptr);
     return std::vector<int64_t>(begin, begin + size);
-  } else if (dtype.is(py::dtype::of<uint8_t>()) ||
-             dtype.is(py::dtype::of<bool>())) {
+  } else if (dtype.equal(py::dtype::of<uint8_t>()) ||
+             dtype.equal(py::dtype::of<bool>())) {
     auto begin = reinterpret_cast<uint8_t *>(ptr);
     return std::vector<uint8_t>(begin, begin + size);
-  } else if (dtype.is(py::dtype::of<uint16_t>())) {
+  } else if (dtype.equal(py::dtype::of<uint16_t>())) {
     auto begin = reinterpret_cast<uint16_t *>(ptr);
     return std::vector<uint16_t>(begin, begin + size);
-  } else if (dtype.is(py::dtype::of<uint32_t>())) {
+  } else if (dtype.equal(py::dtype::of<uint32_t>())) {
     auto begin = reinterpret_cast<uint32_t *>(ptr);
     return std::vector<uint32_t>(begin, begin + size);
-  } else if (dtype.is(py::dtype::of<uint64_t>())) {
+  } else if (dtype.equal(py::dtype::of<uint64_t>())) {
     auto begin = reinterpret_cast<uint64_t *>(ptr);
     return std::vector<uint64_t>(begin, begin + size);
-  } else if (dtype.is(py::dtype::of<float>())) {
+  } else if (dtype.equal(py::dtype::of<float>())) {
     auto begin = reinterpret_cast<float *>(ptr);
     return std::vector<float>(begin, begin + size);
-  } else if (dtype.is(py::dtype::of<double>())) {
+  } else if (dtype.equal(py::dtype::of<double>())) {
     auto begin = reinterpret_cast<double *>(ptr);
     return std::vector<double>(begin, begin + size);
   }


### PR DESCRIPTION
Fixed dtype comparison to use `equal` instead of `is`.