### PR TITLE
Fixed bug in YAML conversion of "[bool]" properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Fixed typo in wall-disc collision computation.
 - Fixed dtype comparison to use `equal` instead of `is`.
 - Fixed documentation errors.
+- Fixed YAML serialization of `std::vector<bool>` which caused empty list to be serialized as a null node instead of an empty list.
 
 ### Changed
 

--- a/navground_core/include/navground/core/yaml/property.h
+++ b/navground_core/include/navground/core/yaml/property.h
@@ -39,7 +39,7 @@ struct convert<Vector2> {
 template <>
 struct convert<std::vector<bool>> {
   static Node encode(const std::vector<bool>& rhs) {
-    Node node;
+    Node node(NodeType::Sequence);
     for (const bool& item : rhs) {
       node.push_back(item);
     }
@@ -47,6 +47,7 @@ struct convert<std::vector<bool>> {
   }
   static bool decode(const Node& node, std::vector<bool>& rhs) {
     if (node.Type() != YAML::NodeType::Sequence) return false;
+    rhs.clear();
     for (const auto& c : node) {
       rhs.push_back(c.as<bool>());
     }


### PR DESCRIPTION
Fixed the conversion of `std::vector<bool>` to encode empty lists to `[]` (vs `~`). Now uses the same function as the other vector types.